### PR TITLE
Add auto-update script for Pi deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ sensor:
       value_template: "{{ value_json.bedjets_connected }}"
 ```
 
+### Auto-update (optional)
+
+`update.sh` can automatically pull the latest code from main and restart the service. Set it up with cron:
+
+1. Allow passwordless sudo for service restart:
+
+```bash
+sudo bash -c 'echo "pi ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart bedjet" > /etc/sudoers.d/bedjet-update'
+sudo chmod 440 /etc/sudoers.d/bedjet-update
+```
+
+2. Ensure git can pull without a password prompt (SSH key with no passphrase).
+
+3. Add a cron job (checks every 15 minutes):
+
+```bash
+crontab -e
+# Add:
+*/15 * * * * /home/pi/bedjet-mqtt/update.sh >> /var/log/bedjet-update.log 2>&1
+```
+
 ## Diagnostics
 
 Run `diagnose.py` on the Pi to independently test MQTT and BLE connectivity:

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Auto-update bedjet-mqtt from main and restart service if changed.
+# Intended to run via cron on the Pi.
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR" || exit 1
+
+git fetch origin main
+
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+
+if [ "$LOCAL" != "$REMOTE" ]; then
+    echo "$(date): Updating from $LOCAL to $REMOTE"
+    git reset --hard origin/main
+    sudo systemctl restart bedjet
+    echo "$(date): Service restarted"
+else
+    echo "$(date): Already up to date"
+fi

--- a/update.sh
+++ b/update.sh
@@ -2,10 +2,17 @@
 # Auto-update bedjet-mqtt from main and restart service if changed.
 # Intended to run via cron on the Pi.
 
+set -e
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_DIR" || exit 1
 
-git fetch origin main
+# Prevent concurrent runs
+exec 200>/tmp/bedjet-update.lock
+flock -n 200 || { echo "$(date): already running"; exit 0; }
+
+git fetch origin main || { echo "$(date): fetch failed"; exit 1; }
 
 LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/main)
@@ -14,7 +21,12 @@ if [ "$LOCAL" != "$REMOTE" ]; then
     echo "$(date): Updating from $LOCAL to $REMOTE"
     git reset --hard origin/main
     sudo systemctl restart bedjet
-    echo "$(date): Service restarted"
+    sleep 5
+    if ! systemctl is-active --quiet bedjet; then
+        echo "$(date): WARNING — service failed to start after update"
+    else
+        echo "$(date): Service restarted successfully"
+    fi
 else
     echo "$(date): Already up to date"
 fi


### PR DESCRIPTION
## Summary
- Adds `update.sh` — a cron-friendly script that fetches latest main, and only restarts the bedjet service if there are new changes
- No bluetooth reset needed on redeploy; the existing auto-recovery handles cache corruption at runtime

## Setup on Pi
1. `crontab -e` and add: `*/15 * * * * /path/to/bedjet-mqtt/update.sh >> /var/log/bedjet-update.log 2>&1`
2. Ensure passwordless sudo for restart: `pi ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart bedjet`
3. Ensure git can pull without a password prompt (SSH key)

## Test plan
- [ ] Verify script is executable
- [ ] Run manually on Pi and confirm it pulls + restarts only when there are changes
- [ ] Confirm no-op when already up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)